### PR TITLE
alerts client

### DIFF
--- a/.github/workflows/php-sdk-development-tests.yml
+++ b/.github/workflows/php-sdk-development-tests.yml
@@ -99,6 +99,8 @@ jobs:
       - name: Set BOUNCER_KEY env
         run: |
           echo "BOUNCER_KEY=$(ddev create-bouncer)" >> $GITHUB_ENV
+      - name: Create watcher
+        run: ddev create-watcher
 
       - name: Clone Lapi Client files
         if: inputs.is_call != true

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ composer-dev*
 
 #log
 *.log
+
+/cfssl

--- a/composer.json
+++ b/composer.json
@@ -37,14 +37,16 @@
     },
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "crowdsec/common": "^3.0.0",
         "ext-json": "*",
+        "crowdsec/common": "^3.0.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "symfony/config": "^4.4.44 || ^5.4.11 || ^6.0.11 || ^7.2.0"
     },
     "require-dev": {
+        "ext-curl": "*",
         "phpunit/phpunit": "^8.5.30 || ^9.3",
         "mikey179/vfsstream": "^1.6.11",
-        "ext-curl": "*"
+        "symfony/cache": "^5.4.11 || ^6.0.11 || ^7.2.1"
     },
     "suggest": {
         "ext-curl": "*"

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -82,8 +82,8 @@ ddev config --project-type=php --php-version=8.2 --project-name=crowdsec-lapi-cl
 - Add some DDEV add-ons:
 
 ```bash
-ddev get julienloizelet/ddev-tools
-ddev get julienloizelet/ddev-crowdsec-php
+ddev add-on get julienloizelet/ddev-tools
+ddev add-on get julienloizelet/ddev-crowdsec-php
 ```
 
 - Clone this repo sources in a `my-code/lapi-client` folder:

--- a/src/AbstractLapiClient.php
+++ b/src/AbstractLapiClient.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Definition\Processor;
 abstract class AbstractLapiClient extends AbstractClient
 {
     /**
-     * @var TBouncerConfig
+     * @var array|TBouncerConfig
      */
     protected $configs;
     /**
@@ -30,7 +30,7 @@ abstract class AbstractLapiClient extends AbstractClient
     ) {
         $this->configure($configs);
         $this->headers = [Constants::HEADER_LAPI_USER_AGENT => $this->formatUserAgent($this->configs)];
-        if (!empty($this->configs['api_key'])) {
+        if (isset($this->configs['api_key'])) {
             $this->headers[Constants::HEADER_LAPI_API_KEY] = $this->configs['api_key'];
         }
         parent::__construct($this->configs, $requestHandler, $logger);

--- a/src/AbstractLapiClient.php
+++ b/src/AbstractLapiClient.php
@@ -15,7 +15,7 @@ use Symfony\Component\Config\Definition\Processor;
 abstract class AbstractLapiClient extends AbstractClient
 {
     /**
-     * @var array|TBouncerConfig
+     * @var TBouncerConfig
      */
     protected $configs;
     /**

--- a/src/AbstractLapiClient.php
+++ b/src/AbstractLapiClient.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace CrowdSec\LapiClient;
+
+use CrowdSec\Common\Client\AbstractClient;
+use CrowdSec\Common\Client\ClientException as CommonClientException;
+use CrowdSec\Common\Client\RequestHandler\RequestHandlerInterface;
+use CrowdSec\Common\Client\TimeoutException as CommonTimeoutException;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * @psalm-import-type TBouncerConfig from Configuration
+ */
+abstract class AbstractLapiClient extends AbstractClient
+{
+    /**
+     * @var TBouncerConfig
+     */
+    protected $configs;
+    /**
+     * @var array
+     */
+    protected $headers;
+
+    public function __construct(
+        array $configs,
+        ?RequestHandlerInterface $requestHandler = null,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->configure($configs);
+        $this->headers = [Constants::HEADER_LAPI_USER_AGENT => $this->formatUserAgent($this->configs)];
+        if (!empty($this->configs['api_key'])) {
+            $this->headers[Constants::HEADER_LAPI_API_KEY] = $this->configs['api_key'];
+        }
+        parent::__construct($this->configs, $requestHandler, $logger);
+    }
+
+    /**
+     * Process and validate input configurations.
+     */
+    private function configure(array $configs): void
+    {
+        $configuration = new Configuration();
+        $processor = new Processor();
+        $this->configs = $processor->processConfiguration($configuration, [$configuration->cleanConfigs($configs)]);
+    }
+
+    /**
+     * Make a request to LAPI.
+     *
+     * @throws ClientException
+     */
+    protected function manageRequest(
+        string $method,
+        string $endpoint,
+        array $parameters = []
+    ): array {
+        try {
+            $this->logger->debug('Now processing a bouncer request', [
+                'type' => 'BOUNCER_CLIENT_REQUEST',
+                'method' => $method,
+                'endpoint' => $endpoint,
+                'parameters' => $parameters,
+            ]);
+
+            return $this->request($method, $endpoint, $parameters, $this->headers);
+        } catch (CommonTimeoutException $e) {
+            throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
+        } catch (CommonClientException $e) {
+            throw new ClientException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Make a request to the AppSec component of LAPI.
+     *
+     * @throws ClientException
+     */
+    protected function manageAppSecRequest(
+        string $method,
+        array $headers = [],
+        string $rawBody = '',
+    ): array {
+        try {
+            $this->logger->debug('Now processing a bouncer AppSec request', [
+                'type' => 'BOUNCER_CLIENT_APPSEC_REQUEST',
+                'method' => $method,
+                'raw body' => $this->cleanRawBodyForLog($rawBody, 200),
+                'raw body length' => strlen($rawBody),
+                'headers' => $this->cleanHeadersForLog($headers),
+            ]);
+
+            return $this->requestAppSec($method, $headers, $rawBody);
+        } catch (CommonTimeoutException $e) {
+            throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
+        } catch (CommonClientException $e) {
+            throw new ClientException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    protected function cleanHeadersForLog(array $headers): array
+    {
+        $cleanedHeaders = $headers;
+        if (array_key_exists(Constants::HEADER_APPSEC_API_KEY, $cleanedHeaders)) {
+            $cleanedHeaders[Constants::HEADER_APPSEC_API_KEY] = '***';
+        }
+
+        return $cleanedHeaders;
+    }
+
+    protected function cleanRawBodyForLog(string $rawBody, int $maxLength): string
+    {
+        return strlen($rawBody) > $maxLength ? substr($rawBody, 0, $maxLength) . '...[TRUNCATED]' : $rawBody;
+    }
+
+    /**
+     * Format User-Agent header. <PHP LAPI client prefix>_<custom suffix>/<vX.Y.Z>.
+     */
+    protected function formatUserAgent(array $configs = []): string
+    {
+        $userAgentSuffix = !empty($configs['user_agent_suffix']) ? '_' . $configs['user_agent_suffix'] : '';
+        $userAgentVersion =
+            !empty($configs['user_agent_version']) ? $configs['user_agent_version'] : Constants::VERSION;
+
+        return Constants::USER_AGENT_PREFIX . $userAgentSuffix . '/' . $userAgentVersion;
+    }
+}

--- a/src/AlertsClient.php
+++ b/src/AlertsClient.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient;
+
+use CrowdSec\Common\Client\RequestHandler\RequestHandlerInterface;
+use CrowdSec\LapiClient\Storage\TokenStorageInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * @psalm-import-type TAlertFull from \CrowdSec\LapiClient\Payload\Alert
+ * @psalm-import-type TDecision from \CrowdSec\LapiClient\Payload\Alert
+ * @psalm-import-type TEvent from \CrowdSec\LapiClient\Payload\Alert
+ * @psalm-import-type TMeta from \CrowdSec\LapiClient\Payload\Alert
+ * @psalm-import-type TSource from \CrowdSec\LapiClient\Payload\Alert
+ *
+ * @psalm-type TSearchQuery = array{
+ *     scope?: string,
+ *     value?: string,
+ *     scenario?: string,
+ *     ip?: string,
+ *     range?: string,
+ *     since?: string,
+ *     until?: string,
+ *     simulated?: boolean,
+ *     has_active_decision?: boolean,
+ *     decision_type?: string,
+ *     limit?: number,
+ *     origin?: string
+ * }
+ *
+ * @psalm-type TDeleteQuery = array{
+ *     scope?: string,
+ *     value?: string,
+ *     scenario?: string,
+ *     ip?: string,
+ *     range?: string,
+ *     since?: string,
+ *     until?: string,
+ *     has_active_decision?: boolean,
+ *     alert_source?: string
+ * }
+ *
+ * @psalm-type TStoredAlert = array{
+ *     capacity: int,
+ *     created_at: string,
+ *     decisions: list<TDecision>,
+ *     events: list<TEvent>,
+ *     events_count: int,
+ *     id: int,
+ *     labels: null|array<string, mixed>,
+ *     leakspeed: string,
+ *     machine_id: string,
+ *     message: string,
+ *     meta: list<TMeta>,
+ *     scenario: string,
+ *     scenario_hash: string,
+ *     scenario_version: string,
+ *     simulated: bool,
+ *     source: TSource,
+ *     start_at: string,
+ *     stop_at: string,
+ *     uuid: string
+ * }
+ */
+class AlertsClient extends AbstractLapiClient
+{
+    /**
+     * @var TokenStorageInterface
+     */
+    private $tokenStorage;
+
+    public function __construct(
+        array $configs,
+        TokenStorageInterface $tokenStorage,
+        ?RequestHandlerInterface $requestHandler = null,
+        ?LoggerInterface $logger = null
+    ) {
+        $this->tokenStorage = $tokenStorage;
+        parent::__construct($configs, $requestHandler, $logger);
+    }
+
+    /**
+     * @param list<TAlertFull> $alerts
+     *
+     * @return list<string>
+     */
+    public function push(array $alerts): array
+    {
+        $this->login();
+        return $this->manageRequest(
+            'POST',
+            Constants::ALERTS,
+            $alerts
+        );
+    }
+
+    /**
+     * Search for alerts.
+     *
+     *     scope - Show alerts for this scope.
+     *     value - Show alerts for this value (used with scope).
+     *     scenario - Show alerts for this scenario.
+     *     ip - IP to search for (shorthand for scope=ip&value=).
+     *     range - Range to search for (shorthand for scope=range&value=).
+     *     since - Search alerts newer than delay (format must be compatible with time.ParseDuration).
+     *     until - Search alerts older than delay (format must be compatible with time.ParseDuration).
+     *     simulated - If set to true, decisions in simulation mode will be returned as well.
+     *     has_active_decision: Only return alerts with decisions not expired yet.
+     *     decision_type: Restrict results to alerts with decisions matching given type.
+     *     limit: Number of alerts to return.
+     *     origin: Restrict results to this origin (ie. lists,CAPI,cscli).
+     *
+     * @param TSearchQuery $query
+     * @return list<TStoredAlert>
+     */
+    public function search(array $query): array
+    {
+        $this->login();
+        return $this->manageRequest(
+            'GET',
+            Constants::ALERTS,
+            $query
+        );
+    }
+
+    /**
+     * Delete alerts by condition. Can be used only on the same machine than the local API.
+     *
+     * @param TDeleteQuery $query
+     */
+    public function delete(array $query): array
+    {
+        $this->login();
+        return $this->manageRequest(
+            'DELETE',
+            Constants::ALERTS,
+            $query
+        );
+    }
+
+    /**
+     * @param positive-int $id
+     * @return TStoredAlert
+     */
+    public function getById(int $id): ?array
+    {
+        $this->login();
+        $result = $this->manageRequest(
+            'GET',
+            \sprintf('%s/%d', Constants::ALERTS, $id)
+        );
+        // workaround for mutes 404 status.
+        if (empty($result['id'])) {
+            \assert($result['message'] === 'object not found');
+            return null;
+        }
+        return $result;
+    }
+
+    private function login(): void
+    {
+        $token = $this->tokenStorage->retrieveToken();
+        if (null === $token) {
+            throw new ClientException('Login fail');
+        }
+        $this->headers['Authorization'] = "Bearer $token";
+    }
+}

--- a/src/Bouncer.php
+++ b/src/Bouncer.php
@@ -4,13 +4,6 @@ declare(strict_types=1);
 
 namespace CrowdSec\LapiClient;
 
-use CrowdSec\Common\Client\AbstractClient;
-use CrowdSec\Common\Client\ClientException as CommonClientException;
-use CrowdSec\Common\Client\RequestHandler\RequestHandlerInterface;
-use CrowdSec\Common\Client\TimeoutException as CommonTimeoutException;
-use Psr\Log\LoggerInterface;
-use Symfony\Component\Config\Definition\Processor;
-
 /**
  * The Bouncer Client.
  *
@@ -21,35 +14,14 @@ use Symfony\Component\Config\Definition\Processor;
  * @copyright Copyright (c) 2022+ CrowdSec
  * @license   MIT License
  *
- * @psalm-import-type TMetric from Metrics
- * @psalm-import-type TOS     from Metrics
- * @psalm-import-type TMeta   from Metrics
- * @psalm-import-type TItem   from Metrics
+ * @psalm-import-type TMetric       from \CrowdSec\LapiClient\Metrics
+ * @psalm-import-type TOS           from \CrowdSec\LapiClient\Metrics
+ * @psalm-import-type TMeta         from \CrowdSec\LapiClient\Metrics
+ * @psalm-import-type TItem         from \CrowdSec\LapiClient\Metrics
+ * @psalm-import-type TBouncerConfig from \CrowdSec\LapiClient\Configuration
  */
-class Bouncer extends AbstractClient
+class Bouncer extends AbstractLapiClient
 {
-    /**
-     * @var array
-     */
-    protected $configs;
-    /**
-     * @var array
-     */
-    private $headers;
-
-    public function __construct(
-        array $configs,
-        ?RequestHandlerInterface $requestHandler = null,
-        ?LoggerInterface $logger = null
-    ) {
-        $this->configure($configs);
-        $this->headers = [Constants::HEADER_LAPI_USER_AGENT => $this->formatUserAgent($this->configs)];
-        if (!empty($this->configs['api_key'])) {
-            $this->headers[Constants::HEADER_LAPI_API_KEY] = $this->configs['api_key'];
-        }
-        parent::__construct($this->configs, $requestHandler, $logger);
-    }
-
     /**
      * Helper to create well formatted metrics array.
      *
@@ -62,19 +34,18 @@ class Bouncer extends AbstractClient
      *        'version' => (string) Bouncer version
      *        'feature_flags' => (array) Should be empty for bouncer
      *        'utc_startup_timestamp' => (integer) Bouncer startup timestamp
+     *        'os' => (array) OS information
      *        'os' = [
      *            'name' => (string) OS name
      *            'version' => (string) OS version
      *        ]
      *    ];
-     *
      * @param TMeta $meta Array containing meta data.
      *
      *    $meta = [
      *        'window_size_seconds' => (integer) Window size in seconds
      *        'utc_now_timestamp' => (integer) Current timestamp
      *    ];
-     *
      * @param list<TItem|array> $items Array of items. Each item is an array too.
      *
      *    $items = [
@@ -196,43 +167,6 @@ class Bouncer extends AbstractClient
         );
     }
 
-    private function cleanHeadersForLog(array $headers): array
-    {
-        $cleanedHeaders = $headers;
-        if (array_key_exists(Constants::HEADER_APPSEC_API_KEY, $cleanedHeaders)) {
-            $cleanedHeaders[Constants::HEADER_APPSEC_API_KEY] = '***';
-        }
-
-        return $cleanedHeaders;
-    }
-
-    private function cleanRawBodyForLog(string $rawBody, int $maxLength): string
-    {
-        return strlen($rawBody) > $maxLength ? substr($rawBody, 0, $maxLength) . '...[TRUNCATED]' : $rawBody;
-    }
-
-    /**
-     * Process and validate input configurations.
-     */
-    private function configure(array $configs): void
-    {
-        $configuration = new Configuration();
-        $processor = new Processor();
-        $this->configs = $processor->processConfiguration($configuration, [$configuration->cleanConfigs($configs)]);
-    }
-
-    /**
-     * Format User-Agent header. <PHP LAPI client prefix>_<custom suffix>/<vX.Y.Z>.
-     */
-    private function formatUserAgent(array $configs = []): string
-    {
-        $userAgentSuffix = !empty($configs['user_agent_suffix']) ? '_' . $configs['user_agent_suffix'] : '';
-        $userAgentVersion =
-            !empty($configs['user_agent_version']) ? $configs['user_agent_version'] : Constants::VERSION;
-
-        return Constants::USER_AGENT_PREFIX . $userAgentSuffix . '/' . $userAgentVersion;
-    }
-
     /**
      * @return TOS
      */
@@ -242,58 +176,5 @@ class Bouncer extends AbstractClient
             'name' => php_uname('s'),
             'version' => php_uname('v'),
         ];
-    }
-
-    /**
-     * Make a request to the AppSec component of LAPI.
-     *
-     * @throws ClientException
-     */
-    private function manageAppSecRequest(
-        string $method,
-        array $headers = [],
-        string $rawBody = ''
-    ): array {
-        try {
-            $this->logger->debug('Now processing a bouncer AppSec request', [
-                'type' => 'BOUNCER_CLIENT_APPSEC_REQUEST',
-                'method' => $method,
-                'raw body' => $this->cleanRawBodyForLog($rawBody, 200),
-                'raw body length' => strlen($rawBody),
-                'headers' => $this->cleanHeadersForLog($headers),
-            ]);
-
-            return $this->requestAppSec($method, $headers, $rawBody);
-        } catch (CommonTimeoutException $e) {
-            throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
-        } catch (CommonClientException $e) {
-            throw new ClientException($e->getMessage(), $e->getCode(), $e);
-        }
-    }
-
-    /**
-     * Make a request to LAPI.
-     *
-     * @throws ClientException
-     */
-    private function manageRequest(
-        string $method,
-        string $endpoint,
-        array $parameters = []
-    ): array {
-        try {
-            $this->logger->debug('Now processing a bouncer request', [
-                'type' => 'BOUNCER_CLIENT_REQUEST',
-                'method' => $method,
-                'endpoint' => $endpoint,
-                'parameters' => $parameters,
-            ]);
-
-            return $this->request($method, $endpoint, $parameters, $this->headers);
-        } catch (CommonTimeoutException $e) {
-            throw new TimeoutException($e->getMessage(), $e->getCode(), $e);
-        } catch (CommonClientException $e) {
-            throw new ClientException($e->getMessage(), $e->getCode(), $e);
-        }
     }
 }

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -40,7 +40,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class Configuration extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'user_agent_suffix',
         'user_agent_version',

--- a/src/Configuration.php
+++ b/src/Configuration.php
@@ -25,7 +25,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  *     api_url?: string,
  *     appsec_url?: string,
  *     auth_type?: string,
- *     api_key: string,
+ *     api_key?: string,
  *     tls_cert_path?: string,
  *     tls_key_path?: string,
  *     tls_ca_cert_path?: string,
@@ -34,6 +34,8 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  *     api_connect_timeout?: int,
  *     appsec_timeout_ms?: int,
  *     appsec_connect_timeout_ms?: int,
+ *     machine_id?: non-empty-string,
+ *     password?: non-empty-string
  * }
  */
 class Configuration extends AbstractConfiguration
@@ -54,6 +56,8 @@ class Configuration extends AbstractConfiguration
         'api_connect_timeout',
         'appsec_timeout_ms',
         'appsec_connect_timeout_ms',
+        'machine_id',
+        'password',
     ];
 
     /**
@@ -92,6 +96,7 @@ class Configuration extends AbstractConfiguration
         $this->addConnectionNodes($rootNode);
         $this->addAppSecNodes($rootNode);
         $this->validate($rootNode);
+        $this->watcher($rootNode);
 
         return $treeBuilder;
     }
@@ -105,7 +110,7 @@ class Configuration extends AbstractConfiguration
      *
      * @throws \InvalidArgumentException
      */
-    private function addAppSecNodes($rootNode)
+    private function addAppSecNodes($rootNode): void
     {
         $rootNode->children()
             ->scalarNode('appsec_url')->cannotBeEmpty()->defaultValue(Constants::DEFAULT_APPSEC_URL)->end()
@@ -123,7 +128,7 @@ class Configuration extends AbstractConfiguration
      *
      * @throws \InvalidArgumentException
      */
-    private function addConnectionNodes($rootNode)
+    private function addConnectionNodes($rootNode): void
     {
         $rootNode->children()
             ->scalarNode('api_url')->cannotBeEmpty()->defaultValue(Constants::DEFAULT_LAPI_URL)->end()
@@ -162,7 +167,7 @@ class Configuration extends AbstractConfiguration
      * @throws \InvalidArgumentException
      * @throws \RuntimeException
      */
-    private function validate($rootNode)
+    private function validate($rootNode): void
     {
         $rootNode
             ->validate()
@@ -194,6 +199,14 @@ class Configuration extends AbstractConfiguration
                     return false;
                 })
                 ->thenInvalid('CA path is required for tls authentification with verify_peer.')
+        ->end();
+    }
+
+    private function watcher(ArrayNodeDefinition $rootNode): void
+    {
+        $rootNode->children()
+            ->stringNode('machine_id')->end()
+            ->stringNode('password')->end()
         ->end();
     }
 }

--- a/src/Configuration/Alert.php
+++ b/src/Configuration/Alert.php
@@ -10,7 +10,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Alert extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'scenario',
         'scenario_hash',

--- a/src/Configuration/Alert.php
+++ b/src/Configuration/Alert.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient\Configuration;
+
+use CrowdSec\Common\Configuration\AbstractConfiguration;
+use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class Alert extends AbstractConfiguration
+{
+    /** @var list<string> The list of each configuration tree key */
+    protected $keys = [
+        'scenario',
+        'scenario_hash',
+        'scenario_version',
+        'message',
+        'events_count',
+        'start_at',
+        'stop_at',
+        'capacity',
+        'leakspeed',
+        'simulated',
+        'remediation',
+    ];
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('alert');
+        /** @var ArrayNodeDefinition $rootNode */
+        $rootNode = $treeBuilder->getRootNode();
+
+        // @formatter:off
+        $rootNode
+            ->children()
+                ->stringNode('scenario')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('scenario_hash')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('scenario_version')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('message')->isRequired()->cannotBeEmpty()->end()
+                ->integerNode('events_count')->isRequired()->min(0)->end()
+                ->scalarNode('start_at')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('stop_at')->isRequired()->cannotBeEmpty()->end()
+                ->integerNode('capacity')->isRequired()->min(0)->end()
+                ->scalarNode('leakspeed')->isRequired()->cannotBeEmpty()->end()
+                ->booleanNode('simulated')->isRequired()->end()
+                ->booleanNode('remediation')->isRequired()->end()
+            ->end()
+        ;
+        // @formatter:on
+
+        return $treeBuilder;
+    }
+}

--- a/src/Configuration/Alert/Decision.php
+++ b/src/Configuration/Alert/Decision.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Decision extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'origin',
         'type',

--- a/src/Configuration/Alert/Decision.php
+++ b/src/Configuration/Alert/Decision.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CrowdSec\LapiClient\Configuration\Alert;
+
+use CrowdSec\Common\Configuration\AbstractConfiguration;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class Decision extends AbstractConfiguration
+{
+    /** @var list<string> The list of each configuration tree key */
+    protected $keys = [
+        'origin',
+        'type',
+        'scope',
+        'value',
+        'duration',
+        'until',
+        'scenario',
+    ];
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('decision');
+        $rootNode = $treeBuilder->getRootNode();
+
+        // @formatter:off
+        $rootNode
+            ->children()
+                ->stringNode('origin')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('type')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('scope')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('value')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('duration')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('until')->cannotBeEmpty()->end()
+                ->stringNode('scenario')->isRequired()->cannotBeEmpty()->end()
+            ->end()
+        ;
+        // @formatter:on
+
+        return $treeBuilder;
+    }
+}

--- a/src/Configuration/Alert/Event.php
+++ b/src/Configuration/Alert/Event.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace CrowdSec\LapiClient\Configuration\Alert;
+
+use CrowdSec\Common\Configuration\AbstractConfiguration;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class Event extends AbstractConfiguration
+{
+    /** @var list<string> The list of each configuration tree key */
+    protected $keys = [
+        'meta',
+        'timestamp',
+    ];
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('event');
+        $rootNode = $treeBuilder->getRootNode();
+
+        // @formatter:off
+        $rootNode
+            ->children()
+                ->arrayNode('meta')->isRequired()
+                    ->arrayPrototype()
+                        ->children()
+                            ->stringNode('key')->isRequired()->cannotBeEmpty()->end()
+                            ->stringNode('value')->isRequired()->cannotBeEmpty()->end()
+                        ->end()
+                    ->end()
+                ->end()
+                ->scalarNode('timestamp')->isRequired()->cannotBeEmpty()->end()
+            ->end()
+        ;
+        // @formatter:on
+
+        return $treeBuilder;
+    }
+}

--- a/src/Configuration/Alert/Event.php
+++ b/src/Configuration/Alert/Event.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Event extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'meta',
         'timestamp',

--- a/src/Configuration/Alert/Meta.php
+++ b/src/Configuration/Alert/Meta.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CrowdSec\LapiClient\Configuration\Alert;
+
+use CrowdSec\Common\Configuration\AbstractConfiguration;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class Meta extends AbstractConfiguration
+{
+    /** @var list<string> The list of each configuration tree key */
+    protected $keys = [
+        'key',
+        'value',
+    ];
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('meta');
+        $root = $treeBuilder->getRootNode();
+
+        // @formatter:off
+        $root
+            ->children()
+                ->scalarNode('key')->isRequired()->cannotBeEmpty()->end()
+                ->scalarNode('value')->isRequired()->cannotBeEmpty()->end()
+            ->end();
+        // @formatter:on
+
+        return $treeBuilder;
+    }
+}

--- a/src/Configuration/Alert/Meta.php
+++ b/src/Configuration/Alert/Meta.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Meta extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'key',
         'value',

--- a/src/Configuration/Alert/Source.php
+++ b/src/Configuration/Alert/Source.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace CrowdSec\LapiClient\Configuration\Alert;
+
+use CrowdSec\Common\Configuration\AbstractConfiguration;
+use Symfony\Component\Config\Definition\Builder\TreeBuilder;
+
+class Source extends AbstractConfiguration
+{
+    /** @var list<string> The list of each configuration tree key */
+    protected $keys = [
+        'scope',
+        'value',
+        'ip',
+        'range',
+        'as_number',
+        'as_name',
+        'cn',
+        'latitude',
+        'longitude',
+    ];
+
+    public function getConfigTreeBuilder(): TreeBuilder
+    {
+        $treeBuilder = new TreeBuilder('source');
+        $rootNode = $treeBuilder->getRootNode();
+
+        // @formatter:off
+        $rootNode
+            ->children()
+                ->stringNode('scope')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('value')->isRequired()->cannotBeEmpty()->end()
+                ->stringNode('ip')->cannotBeEmpty()->end()
+                ->stringNode('range')->cannotBeEmpty()->end()
+                ->scalarNode('as_number')->cannotBeEmpty()->end()
+                ->stringNode('as_name')->cannotBeEmpty()->end()
+                ->stringNode('cn')->cannotBeEmpty()->end()
+                ->floatNode('latitude')->min(-90)->max(90)->end()
+                ->floatNode('longitude')->min(-180)->max(180)->end()
+            ->end()
+        ;
+        // @formatter:on
+
+        return $treeBuilder;
+    }
+}

--- a/src/Configuration/Alert/Source.php
+++ b/src/Configuration/Alert/Source.php
@@ -7,7 +7,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 
 class Source extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'scope',
         'value',

--- a/src/Configuration/Metrics.php
+++ b/src/Configuration/Metrics.php
@@ -21,7 +21,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class Metrics extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'name',
         'type',

--- a/src/Configuration/Metrics/Items.php
+++ b/src/Configuration/Metrics/Items.php
@@ -63,13 +63,13 @@ class Items extends AbstractConfiguration
                     ->variableNode('labels')
                         // Remove empty labels totally
                         ->beforeNormalization()
-                            ->ifTrue(function ($value) {
+                            ->ifTrue(function (mixed $value) {
                                 return empty($value);
                             })
                             ->thenUnset()
                         ->end()
                         ->validate()
-                            ->ifTrue(function ($value) {
+                            ->ifTrue(function (mixed $value) {
                                 // Ensure all values in the array are strings
                                 if (!is_array($value)) {
                                     return true;

--- a/src/Configuration/Metrics/Items.php
+++ b/src/Configuration/Metrics/Items.php
@@ -20,7 +20,7 @@ use Symfony\Component\Config\Definition\Builder\TreeBuilder;
  */
 class Items extends AbstractConfiguration
 {
-    /** @var list<string> The list of each configuration tree key */
+    /** @var string[] The list of each configuration tree key */
     protected $keys = [
         'name',
         'value',

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -18,34 +18,50 @@ use CrowdSec\Common\Constants as CommonConstants;
  */
 class Constants extends CommonConstants
 {
+    //<editor-fold desc="Endpoints">
     /**
      * @var string The decisions endpoint
      */
     public const DECISIONS_FILTER_ENDPOINT = '/v1/decisions';
+
     /**
      * @var string The decisions stream endpoint
      */
     public const DECISIONS_STREAM_ENDPOINT = '/v1/decisions/stream';
+
+    public const ALERTS = '/v1/alerts';
+
     /**
-     * @var string The Default URL of the CrowdSec AppSec endpoint
+     * @var string Authenticate current to get session ID
      */
-    public const DEFAULT_APPSEC_URL = 'http://localhost:7422';
-    /**
-     * @var string The Default URL of the CrowdSec LAPI
-     */
-    public const DEFAULT_LAPI_URL = 'http://localhost:8080';
+    public const WATCHER_LOGIN_ENDPOINT = '/v1/watchers/login';
+
     /**
      * @var string The usage metrics endpoint
      */
     public const METRICS_ENDPOINT = '/v1/usage-metrics';
+    //</editor-fold desc="Endpoints">
+
+    /**
+     * @var string The Default URL of the CrowdSec AppSec endpoint
+     */
+    public const DEFAULT_APPSEC_URL = 'http://localhost:7422';
+
+    /**
+     * @var string The Default URL of the CrowdSec LAPI
+     */
+    public const DEFAULT_LAPI_URL = 'http://localhost:8080';
+
     /**
      * @var string The metrics type
      */
     public const METRICS_TYPE = 'crowdsec-php-bouncer';
+
     /**
      * @var string The user agent prefix used to send request to LAPI
      */
     public const USER_AGENT_PREFIX = 'csphplapi';
+
     /**
      * @var string The current version of this library
      */

--- a/src/Metrics.php
+++ b/src/Metrics.php
@@ -92,7 +92,7 @@ class Metrics
     public function __construct(
         array $properties,
         array $meta,
-        array $items = []
+        array $items = [],
     ) {
         $this->configureProperties($properties);
         $this->configureMeta($meta);

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -131,7 +131,7 @@ class Alert implements \JsonSerializable
         $this->configureSource($processor, $source);
         $this->configureDecisions($processor, $decisions);
         $this->configureEvents($processor, $events);
-        $this->configureMetaList($processor, $meta);
+        $this->configureMeta($processor, $meta);
         $this->labels = \array_filter($labels);
     }
 
@@ -212,7 +212,7 @@ class Alert implements \JsonSerializable
     /**
      * @param list<TMeta> $list
      */
-    private function configureMetaList(Processor $processor, array $list): void
+    private function configureMeta(Processor $processor, array $list): void
     {
         $this->meta = $this->handleList($processor, new Meta(), $list);
     }

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -217,9 +217,6 @@ class Alert implements \JsonSerializable
         $this->meta = $this->handleList($processor, new Meta(), $list);
     }
 
-    /**
-     * @return list<TMeta>
-     */
     private function handleList(Processor $processor, AbstractConfiguration $param, array $list): array
     {
         $result = [];

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -230,7 +230,7 @@ class Alert implements \JsonSerializable
         return $result;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -217,6 +217,9 @@ class Alert implements \JsonSerializable
         $this->meta = $this->handleList($processor, new Meta(), $list);
     }
 
+    /**
+     * @return list<TMeta>
+     */
     private function handleList(Processor $processor, AbstractConfiguration $param, array $list): array
     {
         $result = [];

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -132,7 +132,7 @@ class Alert implements \JsonSerializable
         $this->configureDecisions($processor, $decisions);
         $this->configureEvents($processor, $events);
         $this->configureMeta($processor, $meta);
-        $this->labels = \array_filter($labels);
+        $this->labels = $labels;
     }
 
     /**

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -1,0 +1,237 @@
+<?php
+
+namespace CrowdSec\LapiClient\Payload;
+
+use CrowdSec\Common\Configuration\AbstractConfiguration;
+use CrowdSec\LapiClient\Configuration\Alert as AlertConf;
+use CrowdSec\LapiClient\Configuration\Alert\Decision;
+use CrowdSec\LapiClient\Configuration\Alert\Event;
+use CrowdSec\LapiClient\Configuration\Alert\Meta;
+use CrowdSec\LapiClient\Configuration\Alert\Source;
+use Symfony\Component\Config\Definition\Processor;
+
+/**
+ * Only for validation purposes.
+ *
+ * @psalm-type TProps = array{
+ *     scenario: string,
+ *     scenario_hash: string,
+ *     scenario_version: string,
+ *     message: string,
+ *     events_count: int,
+ *     start_at: string,
+ *     stop_at: string,
+ *     capacity: int,
+ *     leakspeed: string,
+ *     simulated: bool,
+ *     remediation: bool
+ * }
+ *
+ * @psalm-type TSource = array{
+ *     scope: string,
+ *     value: string,
+ *     ip?: string,
+ *     range?: string,
+ *     as_number?: string,
+ *     as_name?: string,
+ *     cn?: string,
+ *     latitude?: float,
+ *     longitude?: float
+ * }
+ *
+ * @psalm-type TDecision = array{
+ *     origin: string,
+ *     type: string,
+ *     scope: string,
+ *     value: string,
+ *     duration: string,
+ *     until?: string,
+ *     scenario: string
+ * }
+ *
+ * @psalm-type TMeta = array{
+ *     key: string,
+ *     value: string
+ * }
+ *
+ * @psalm-type TEvent = array{
+ *     meta: list<TMeta>,
+ *     timestamp: string
+ * }
+ *
+ * @psalm-type TAlertFull = array{
+ *     scenario: string,
+ *     scenario_hash: string,
+ *     scenario_version: string,
+ *     message: string,
+ *     events_count: int,
+ *     start_at: string,
+ *     stop_at: string,
+ *     capacity: int,
+ *     leakspeed: string,
+ *     simulated: bool,
+ *     remediation: bool,
+ *     source: TSource,
+ *     events: list<TEvent>,
+ *     decisions: list<TDecision>,
+ *     meta: list<TMeta>,
+ *     labels: list<non-empty-string>
+ * }
+ */
+class Alert implements \JsonSerializable
+{
+    /**
+     * @var list<TProps>
+     */
+    private $properties;
+
+    /**
+     * @var list<TEvent>
+     */
+    private $events;
+
+    /**
+     * @var list<TDecision>
+     */
+    private $decisions = [];
+
+    /**
+     * @var TSource
+     */
+    private $source;
+
+    /**
+     * @var list<TMeta>
+     */
+    private $meta = [];
+
+    /**
+     * @var list<string>
+     */
+    private $labels = [];
+
+    /**
+     * @param TProps $properties
+     * @param TSource $source
+     * @param list<TEvent> $events
+     * @param list<TDecision> $decisions
+     * @param list<TMeta> $meta
+     * @param list<string> $labels
+     */
+    public function __construct(
+        array $properties,
+        array $source,
+        array $events = [],
+        array $decisions = [],
+        array $meta = [],
+        array $labels = []
+    ) {
+        $processor = new Processor();
+        $this->configureProperties($processor, $properties);
+        $this->configureSource($processor, $source);
+        $this->configureDecisions($processor, $decisions);
+        $this->configureEvents($processor, $events);
+        $this->configureMetaList($processor, $meta);
+        $this->labels = \array_filter($labels);
+    }
+
+    /**
+     * @param TAlertFull $data
+     * @return void
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            $data,
+            $data['source'] ?? [],
+            $data['events'] ?? [],
+            $data['decisions'] ?? [],
+            $data['meta'] ?? [],
+            $data['labels'] ?? []
+        );
+    }
+
+    /**
+     * @return TAlertFull
+     */
+    public function toArray(): array
+    {
+        $result = $this->properties;
+        if ([] !== $this->decisions) {
+            $result['decisions'] = $this->decisions;
+        }
+        if ([] !== $this->events) {
+            $result['events'] = $this->events;
+        }
+        if (null !== $this->source) {
+            $result['source'] = $this->source;
+        }
+        if ([] !== $this->meta) {
+            $result['meta'] = $this->meta;
+        }
+        if ([] !== $this->labels) {
+            $result['labels'] = $this->labels;
+        }
+        return $result;
+    }
+
+    private function configureProperties(Processor $processor, array $properties): void
+    {
+        $configuration = new AlertConf();
+        $this->properties = $processor->processConfiguration(
+            $configuration,
+            [$configuration->cleanConfigs($properties)]
+        );
+    }
+
+    /**
+     * @param ?TSource $source
+     */
+    private function configureSource(Processor $processor, ?array $source): void
+    {
+        if (null === $source) {
+            return;
+        }
+
+        $configuration = new Source();
+        $this->source = $processor->processConfiguration($configuration, [$configuration->cleanConfigs($source)]);
+    }
+
+    /**
+     * @param list<TDecision> $list
+     */
+    private function configureDecisions(Processor $processor, array $list): void
+    {
+        $this->decisions = $this->handleList($processor, new Decision(), $list);
+    }
+
+    /**
+     * @param list<TEvent> $list
+     */
+    private function configureEvents(Processor $processor, array $list): void
+    {
+        $this->events = $this->handleList($processor, new Event(), $list);
+    }
+
+    /**
+     * @param list<TMeta> $list
+     */
+    private function configureMetaList(Processor $processor, array $list): void
+    {
+        $this->meta = $this->handleList($processor, new Meta(), $list);
+    }
+
+    private function handleList(Processor $processor, AbstractConfiguration $param, array $list): array
+    {
+        $result = [];
+        foreach ($list as $item) {
+            $result[] = $processor->processConfiguration($param, [$param->cleanConfigs($item)]);
+        }
+        return $result;
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->toArray();
+    }
+}

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -137,7 +137,6 @@ class Alert implements \JsonSerializable
 
     /**
      * @param TAlertFull $data
-     * @return void
      */
     public static function fromArray(array $data): self
     {

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -73,9 +73,9 @@ use Symfony\Component\Config\Definition\Processor;
  *     remediation: bool,
  *     source: TSource,
  *     events: list<TEvent>,
- *     decisions: list<TDecision>,
- *     meta: list<TMeta>,
- *     labels: list<non-empty-string>
+ *     decisions?: list<TDecision>,
+ *     meta?: list<TMeta>,
+ *     labels?: list<non-empty-string>
  * }
  */
 class Alert implements \JsonSerializable
@@ -157,8 +157,8 @@ class Alert implements \JsonSerializable
     public function toArray(): array
     {
         $result = $this->properties;
-        $result['events'] = $this->events;
         $result['source'] = $this->source;
+        $result['events'] = $this->events;
         if ([] !== $this->decisions) {
             $result['decisions'] = $this->decisions;
         }

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -157,14 +157,10 @@ class Alert implements \JsonSerializable
     public function toArray(): array
     {
         $result = $this->properties;
+        $result['events'] = $this->events;
+        $result['source'] = $this->source;
         if ([] !== $this->decisions) {
             $result['decisions'] = $this->decisions;
-        }
-        if ([] !== $this->events) {
-            $result['events'] = $this->events;
-        }
-        if (null !== $this->source) {
-            $result['source'] = $this->source;
         }
         if ([] !== $this->meta) {
             $result['meta'] = $this->meta;

--- a/src/Storage/TokenStorage.php
+++ b/src/Storage/TokenStorage.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient\Storage;
+
+use CrowdSec\LapiClient\WatcherClient;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class TokenStorage implements TokenStorageInterface
+{
+    /**
+     * @var WatcherClient
+     */
+    private $watcher;
+
+    /**
+     * @var CacheItemPoolInterface
+     */
+    private $cache;
+    /**
+     * @var array
+     */
+    private $scenarios;
+
+    public function __construct(
+        WatcherClient $watcher,
+        CacheItemPoolInterface $cache,
+        array $scenarios = []
+    ) {
+        $this->watcher = $watcher;
+        $this->cache = $cache;
+        $this->scenarios = $scenarios;
+    }
+
+    public function retrieveToken(): ?string
+    {
+        $ci = $this->cache->getItem('crowdsec_token');
+        if (!$ci->isHit()) {
+            $tokenInfo = $this->watcher->login($this->scenarios);
+            if (200 !== $tokenInfo['code']) {
+                return null;
+            }
+            \assert(!empty($tokenInfo['token']));
+            $ci
+                ->set($tokenInfo['token'])
+                ->expiresAt(new \DateTime($tokenInfo['expire']));
+            $this->cache->save($ci);
+        }
+        return $ci->get();
+    }
+}

--- a/src/Storage/TokenStorage.php
+++ b/src/Storage/TokenStorage.php
@@ -42,7 +42,7 @@ final class TokenStorage implements TokenStorageInterface
             if (200 !== $tokenInfo['code']) {
                 return null;
             }
-            \assert(!empty($tokenInfo['token']));
+            \assert(isset($tokenInfo['token']));
             $ci
                 ->set($tokenInfo['token'])
                 ->expiresAt(new DateTime($tokenInfo['expire']));

--- a/src/Storage/TokenStorage.php
+++ b/src/Storage/TokenStorage.php
@@ -24,7 +24,8 @@ final class TokenStorage implements TokenStorageInterface
      */
     private $scenarios;
 
-    public function __construct(WatcherClient $watcher, CacheItemPoolInterface $cache, array $scenarios = []) {
+    public function __construct(WatcherClient $watcher, CacheItemPoolInterface $cache, array $scenarios = [])
+    {
         $this->watcher = $watcher;
         $this->cache = $cache;
         $this->scenarios = $scenarios;

--- a/src/Storage/TokenStorage.php
+++ b/src/Storage/TokenStorage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrowdSec\LapiClient\Storage;
 
 use CrowdSec\LapiClient\WatcherClient;
+use DateTime;
 use Psr\Cache\CacheItemPoolInterface;
 
 final class TokenStorage implements TokenStorageInterface
@@ -44,7 +45,7 @@ final class TokenStorage implements TokenStorageInterface
             \assert(!empty($tokenInfo['token']));
             $ci
                 ->set($tokenInfo['token'])
-                ->expiresAt(new \DateTime($tokenInfo['expire']));
+                ->expiresAt(new DateTime($tokenInfo['expire']));
             $this->cache->save($ci);
         }
         return $ci->get();

--- a/src/Storage/TokenStorage.php
+++ b/src/Storage/TokenStorage.php
@@ -24,11 +24,7 @@ final class TokenStorage implements TokenStorageInterface
      */
     private $scenarios;
 
-    public function __construct(
-        WatcherClient $watcher,
-        CacheItemPoolInterface $cache,
-        array $scenarios = []
-    ) {
+    public function __construct(WatcherClient $watcher, CacheItemPoolInterface $cache, array $scenarios = []) {
         $this->watcher = $watcher;
         $this->cache = $cache;
         $this->scenarios = $scenarios;

--- a/src/Storage/TokenStorageInterface.php
+++ b/src/Storage/TokenStorageInterface.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient\Storage;
+
+interface TokenStorageInterface
+{
+    /**
+     * Retrieve stored token
+     * Return null if not found.
+     */
+    public function retrieveToken(): ?string;
+}

--- a/src/WatcherClient.php
+++ b/src/WatcherClient.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrowdSec\LapiClient;
 
 use CrowdSec\Common\Client\RequestHandler\RequestHandlerInterface;
+use LogicException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -25,7 +26,7 @@ class WatcherClient extends AbstractLapiClient
     ) {
         if ($configs['auth_type'] === Constants::AUTH_KEY) {
             if (empty($configs['machine_id']) || empty($configs['password'])) {
-                throw new \LogicException('Missing required config: machine_id or password.');
+                throw new LogicException('Missing required config: machine_id or password.');
             }
         }
 

--- a/src/WatcherClient.php
+++ b/src/WatcherClient.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient;
+
+use CrowdSec\Common\Client\RequestHandler\RequestHandlerInterface;
+use Psr\Log\LoggerInterface;
+
+/**
+ * If you use `auth_type = api_key` you must provide configs `machine_id` and `password`.
+ *
+ * @psalm-type TLoginResponse = array{
+ *     code: positive-int,
+ *     expire: non-empty-string,
+ *     token: non-empty-string
+ * }
+ */
+class WatcherClient extends AbstractLapiClient
+{
+    public function __construct(
+        array $configs,
+        ?RequestHandlerInterface $requestHandler = null,
+        ?LoggerInterface $logger = null
+    ) {
+        if ($configs['auth_type'] === Constants::AUTH_KEY) {
+            if (empty($configs['machine_id']) || empty($configs['password'])) {
+                throw new \LogicException('Missing required config: machine_id or password.');
+            }
+        }
+
+        parent::__construct($configs, $requestHandler, $logger);
+    }
+
+    /**
+     * @throws ClientException
+     * @return TLoginResponse
+     */
+    public function login(array $scenarios = []): array
+    {
+        $data = [
+            'scenarios' => $scenarios,
+        ];
+        if ($this->configs['auth_type'] === Constants::AUTH_KEY) {
+            $data['machine_id'] = $this->configs['machine_id'];
+            $data['password'] = $this->configs['password'];
+        }
+
+        return $this->manageRequest(
+            'POST',
+            Constants::WATCHER_LOGIN_ENDPOINT,
+            $data
+        );
+    }
+}

--- a/src/WatcherClient.php
+++ b/src/WatcherClient.php
@@ -43,8 +43,8 @@ class WatcherClient extends AbstractLapiClient
             'scenarios' => $scenarios,
         ];
         if ($this->configs['auth_type'] === Constants::AUTH_KEY) {
-            $data['machine_id'] = $this->configs['machine_id'];
-            $data['password'] = $this->configs['password'];
+            $data['machine_id'] = $this->configs['machine_id'] ?? '';
+            $data['password'] = $this->configs['password'] ?? '';
         }
 
         return $this->manageRequest(

--- a/src/WatcherClient.php
+++ b/src/WatcherClient.php
@@ -42,7 +42,7 @@ class WatcherClient extends AbstractLapiClient
         $data = [
             'scenarios' => $scenarios,
         ];
-        if ($this->configs['auth_type'] === Constants::AUTH_KEY) {
+        if (isset($this->configs['auth_type']) && $this->configs['auth_type'] === Constants::AUTH_KEY) {
             $data['machine_id'] = $this->configs['machine_id'] ?? '';
             $data['password'] = $this->configs['password'] ?? '';
         }

--- a/tests/Integration/AlertsClientTest.php
+++ b/tests/Integration/AlertsClientTest.php
@@ -1,0 +1,406 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient\Tests\Integration;
+
+use CrowdSec\LapiClient\AlertsClient;
+use CrowdSec\LapiClient\Constants;
+use CrowdSec\LapiClient\Payload\Alert;
+use CrowdSec\LapiClient\Storage\TokenStorage;
+use CrowdSec\LapiClient\Tests\Constants as TestConstants;
+use CrowdSec\LapiClient\WatcherClient;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * @note You must delete all alerts manually before run this TestCase. Command `cscli alerts delete --all`.
+ *
+ * @coversDefaultClass \CrowdSec\LapiClient\AlertsClient
+ */
+final class AlertsClientTest extends TestCase
+{
+    private const DT_FORMAT = 'Y-m-dTH:i:sZ';
+
+    /**
+     * @var array
+     */
+    protected $configs;
+    /**
+     * @var string
+     */
+    protected $useTls;
+
+    /**
+     * @var AlertsClient
+     */
+    protected $alertsClient;
+
+    private function addTlsConfig(&$bouncerConfigs, $tlsPath)
+    {
+        $bouncerConfigs['tls_cert_path'] = $tlsPath . '/bouncer.pem';
+        $bouncerConfigs['tls_key_path'] = $tlsPath . '/bouncer-key.pem';
+        $bouncerConfigs['tls_ca_cert_path'] = $tlsPath . '/ca-chain.pem';
+        $bouncerConfigs['tls_verify_peer'] = true;
+    }
+
+    protected function setUp(): void
+    {
+        $this->useTls = (string)getenv('BOUNCER_TLS_PATH');
+
+        $bouncerConfigs = [
+            'auth_type' => $this->useTls ? Constants::AUTH_TLS : Constants::AUTH_KEY,
+            'api_key' => getenv('BOUNCER_KEY'),
+            'api_url' => getenv('LAPI_URL'),
+            'appsec_url' => getenv('APPSEC_URL'),
+            'user_agent_suffix' => TestConstants::USER_AGENT_SUFFIX,
+        ];
+        if ($this->useTls) {
+            $this->addTlsConfig($bouncerConfigs, $this->useTls);
+        }
+
+        $this->configs = $bouncerConfigs;
+
+        $watcher = new WatcherClient($this->configs);
+        $tokenStorage = new TokenStorage($watcher, new ArrayAdapter());
+        $this->alertsClient = new AlertsClient($this->configs, $tokenStorage);
+    }
+
+    /**
+     * @covers ::delete
+     */
+    public function testDelete(): void
+    {
+        self::expectException(\RuntimeException::class);
+        $this->alertsClient->delete([]);
+    }
+
+    /**
+     * @covers ::push
+     */
+    public function testPush(): array
+    {
+        $now = new \DateTimeImmutable();
+        $alert01 = new Alert(
+            [
+                'scenario' => 'crowdsec-lapi-test/with-decision',
+                'scenario_hash' => 'alert01',
+                'scenario_version' => '1.0',
+                'message' => 'alert01',
+                'events_count' => 3,
+                'start_at' => $now->format(self::DT_FORMAT),
+                'stop_at' => $now
+                    ->add(new \DateInterval('PT4H'))
+                    ->format(self::DT_FORMAT),
+                'capacity' => 10,
+                'leakspeed' => '10/1s',
+                'simulated' => false,
+                'remediation' => false,
+            ],
+            // source
+            [
+                'scope' => 'ip',
+                'value' => '1.1.0.1',
+                'as_number' => 'AS12345',
+                'as_name' => 'EXAMPLE-AS',
+                'cn' => 'US',
+                'latitude' => 40.7128,
+                'longitude' => -74.0060,
+            ],
+            // events
+            [
+                [
+                    'meta' => [
+                        ['key' => 'path', 'value' => '/alert11'],
+                    ],
+                    'timestamp' => $now->format(self::DT_FORMAT),
+                ],
+            ],
+            // decisions
+            [
+                [
+                    'origin' => 'lapi',
+                    'type' => 'ban',
+                    'scope' => 'ip',
+                    'value' => '1.1.0.1',
+                    'duration' => '4h',
+                    'until' => $now
+                        ->add(new \DateInterval('PT4H'))
+                        ->format(self::DT_FORMAT),
+                    'scenario' => 'crowdsec-lapi-test/with-decision',
+                ],
+            ],
+            [
+                ['key' => 'service', 'value' => 'phpunit'],
+            ],
+            ['http', 'probing']
+        );
+        $alert02 = new Alert(
+            [
+                'scenario' => 'crowdsec-lapi-test/with-decision',
+                'scenario_hash' => 'alert02',
+                'scenario_version' => '1.0',
+                'message' => 'alert02',
+                'events_count' => 3,
+                'start_at' => $now->format(self::DT_FORMAT),
+                'stop_at' => $now
+                    ->add(new \DateInterval('PT4H'))
+                    ->format(self::DT_FORMAT),
+                'capacity' => 10,
+                'leakspeed' => '10/1s',
+                'simulated' => true,
+                'remediation' => true,
+            ],
+            // source
+            [
+                'scope' => 'range',
+                'value' => '1.1.0.0/16',
+                'as_number' => 'AS12345',
+                'as_name' => 'EXAMPLE-AS',
+                'cn' => 'US',
+                'latitude' => 40.7128,
+                'longitude' => -74.0060,
+            ],
+            // events
+            [
+                [
+                    'meta' => [
+                        ['key' => 'path', 'value' => '/alert12'],
+                    ],
+                    'timestamp' => $now->format(self::DT_FORMAT),
+                ],
+            ],
+            // decisions
+            [
+                [
+                    'origin' => 'phpunit',
+                    'type' => 'captcha',
+                    'scope' => 'range',
+                    'value' => '1.1.0.0/16',
+                    'duration' => '4h',
+                    'until' => $now
+                        ->add(new \DateInterval('PT4H'))
+                        ->format(self::DT_FORMAT),
+                    'scenario' => 'crowdsec-lapi-test/with-decision',
+                ],
+            ]
+        );
+        $alert11 = new Alert(
+            [
+                'scenario' => 'crowdsec-lapi-test/integration11',
+                'scenario_hash' => 'alert11',
+                'scenario_version' => '1.0',
+                'message' => 'alert10',
+                'events_count' => 3,
+                'start_at' => $now->format(self::DT_FORMAT),
+                'stop_at' => $now
+                    ->add(new \DateInterval('PT4H'))
+                    ->format(self::DT_FORMAT),
+                'capacity' => 11,
+                'leakspeed' => '10/2s',
+                'simulated' => false,
+                'remediation' => false,
+            ],
+            // source
+            [
+                'scope' => 'ip',
+                'value' => '2.0.1.1',
+                'as_number' => 'AS12345',
+                'as_name' => 'EXAMPLE-AS',
+                'cn' => 'US',
+                'latitude' => 40.7128,
+                'longitude' => -74.0060,
+            ],
+            // events
+            [
+                [
+                    'meta' => [
+                        ['key' => 'path', 'value' => '/alert21'],
+                    ],
+                    'timestamp' => $now->format(self::DT_FORMAT),
+                ],
+            ]
+        );
+        $alert12 = new Alert(
+            [
+                'scenario' => 'crowdsec-lapi-test/integration12',
+                'scenario_hash' => 'alert12',
+                'scenario_version' => '1.0',
+                'message' => 'alert12',
+                'events_count' => 3,
+                'start_at' => $now->format(self::DT_FORMAT),
+                'stop_at' => $now
+                    ->add(new \DateInterval('PT4H'))
+                    ->format(self::DT_FORMAT),
+                'capacity' => 12,
+                'leakspeed' => '10/2s',
+                'simulated' => true,
+                'remediation' => true,
+            ],
+            // source
+            [
+                'scope' => 'range',
+                'value' => '2.0.0.0/16',
+                'as_number' => 'AS12345',
+                'as_name' => 'EXAMPLE-AS',
+                'cn' => 'US',
+                'latitude' => 40.7128,
+                'longitude' => -74.0060,
+            ],
+            // events
+            [
+                [
+                    'meta' => [
+                        ['key' => 'path', 'value' => '/alert21'],
+                    ],
+                    'timestamp' => $now->format(self::DT_FORMAT),
+                ],
+            ]
+        );
+        $result = $this->alertsClient->push([
+            // with decisions
+            $alert01,
+            $alert02,
+            // without decisions
+            $alert11,
+            $alert12,
+        ]);
+        self::assertIsArray($result);
+        self::assertCount(4, $result);
+        return $result;
+    }
+
+    /**
+     * @covers ::search
+     * @depends testPush
+     * @dataProvider searchProvider
+     */
+    public function testSearch(array $query, int $expectedCount): void
+    {
+        $result = $this->alertsClient->search($query);
+        self::assertCount($expectedCount, $result);
+    }
+
+    public static function searchProvider(): iterable
+    {
+        yield 'empty' => [
+            [],
+            4
+        ];
+
+        yield 'ip - no' => [
+            ['ip' => '19.17.11.7'],
+            0
+        ];
+
+        yield 'ip - 1.1.0.1' => [
+            ['ip' => '1.1.0.1'], // alert01 (scope=ip;value=1.1.0.1 +decision) and alert02(scope=range;value=1.1.0.0/16 +decision)
+            2
+        ];
+        yield 'ip - 2.0.1.1' => [
+            ['ip' => '2.0.1.1'], // alert12 (range no decision)
+            1
+        ];
+
+        yield 'scope - ip' => [
+            ['scope' => 'ip'],
+            2,
+        ];
+        yield 'scope - range' => [
+            ['scope' => 'range'],
+            2,
+        ];
+
+        yield 'scope - ip:1.1.0.1' => [
+            ['scope' => 'ip', 'value' => '1.1.0.1'],
+            1,
+        ];
+
+        yield 'scenario' => [
+            ['scenario' => 'crowdsec-lapi-test/with-decision'],
+            2
+        ];
+
+        yield 'has_active_decision=true' => [
+            ['has_active_decision' => 'true'],
+            0,
+        ];
+
+        yield 'has_active_decision=false' => [
+            ['has_active_decision' => 'false'],
+            1, //crowdsec-lapi-test/integration11
+        ];
+// TODO: why 4 byt not 2 ?
+//        yield 'simulated=true' => [
+//            ['simulated' => 'true'],
+//            4,
+//        ];
+        yield 'simulated=false' => [
+            ['simulated' => 'false'],
+            2,
+        ];
+
+        yield 'since -1h' => [
+            [
+                'since' => '-1h',
+            ],
+            0,
+        ];
+        yield 'since 1s' => [
+            ['since' => '1s'],
+            0,
+        ];
+        yield 'since 1h' => [
+            ['since' => '10h'],
+            4,
+        ];
+
+        yield 'until -1h' => [
+            ['until' => '-1h'],
+            4,
+        ];
+        yield 'until 1s' => [
+            ['until' => '1s'],
+            4,
+        ];
+        yield 'until 1h' => [
+            ['until' => '1h'],
+            0,
+        ];
+        yield 'until 10h' => [
+            ['until' => '10h'],
+            0,
+        ];
+        yield 'until 100h' => [
+            ['until' => '10h'],
+            0,
+        ];
+
+        yield 'origin=phpunit' => [
+            ['origin' => 'phpunit'],
+            1,
+        ];
+        yield 'decision_type=ban' => [
+            ['decision_type' => 'ban'],
+            2,
+        ];
+    }
+
+    /**
+     * @depends testPush
+     */
+    public function testGetById(array $idList): void
+    {
+        foreach ($idList as $id) {
+            self::assertIsNumeric($id);
+            $result = $this->alertsClient->getById(\intval($id));
+            self::assertIsArray($result);
+        }
+    }
+
+    public function testAlertInfoNotFound(): void
+    {
+        $result = $this->alertsClient->getById(PHP_INT_MAX);
+        self::assertNull($result);
+    }
+}

--- a/tests/Integration/BouncerTest.php
+++ b/tests/Integration/BouncerTest.php
@@ -36,7 +36,7 @@ final class BouncerTest extends TestCase
      */
     protected $useTls;
     /**
-     * @var WatcherClient
+     * @var TestWatcherClient
      */
     protected $watcherClient;
 
@@ -64,7 +64,7 @@ final class BouncerTest extends TestCase
         }
 
         $this->configs = $bouncerConfigs;
-        $this->watcherClient = new WatcherClient($this->configs);
+        $this->watcherClient = new TestWatcherClient($this->configs);
         // Delete all decisions
         $this->watcherClient->deleteAllDecisions();
         usleep(200000); // 200ms

--- a/tests/Integration/TestWatcherClient.php
+++ b/tests/Integration/TestWatcherClient.php
@@ -7,11 +7,10 @@ namespace CrowdSec\LapiClient\Tests\Integration;
 use CrowdSec\Common\Client\AbstractClient;
 use CrowdSec\LapiClient\ClientException;
 use CrowdSec\LapiClient\Constants;
+use CrowdSec\LapiClient\WatcherClient;
 
-class WatcherClient extends AbstractClient
+class TestWatcherClient extends AbstractClient
 {
-    public const WATCHER_LOGIN_ENDPOINT = '/v1/watchers/login';
-
     public const WATCHER_DECISIONS_ENDPOINT = '/v1/decisions';
 
     public const WATCHER_ALERT_ENDPOINT = '/v1/alerts';
@@ -25,6 +24,9 @@ class WatcherClient extends AbstractClient
      */
     protected $headers = [];
 
+    /** @var WatcherClient */
+    protected $watcher;
+
     public function __construct(array $configs)
     {
         $this->configs = $configs;
@@ -37,6 +39,8 @@ class WatcherClient extends AbstractClient
         $this->configs['tls_cert_path'] = $agentTlsPath . '/agent.pem';
         $this->configs['tls_key_path'] = $agentTlsPath . '/agent-key.pem';
         $this->configs['tls_verify_peer'] = false;
+
+        $this->watcher = new WatcherClient($this->configs);
 
         parent::__construct($this->configs);
     }
@@ -96,15 +100,7 @@ class WatcherClient extends AbstractClient
     private function ensureLogin(): void
     {
         if (!$this->token) {
-            $data = [
-                'scenarios' => [],
-            ];
-            $credentials = $this->manageRequest(
-                'POST',
-                self::WATCHER_LOGIN_ENDPOINT,
-                $data
-            );
-
+            $credentials = $this->watcher->login();
             $this->token = $credentials['token'];
             $this->headers['Authorization'] = 'Bearer ' . $this->token;
         }
@@ -160,8 +156,7 @@ class WatcherClient extends AbstractClient
                     'value' => $value,
                 ],
             ],
-            'events' => [
-            ],
+            'events' => [],
             'events_count' => 1,
             'labels' => null,
             'leakspeed' => '0',

--- a/tests/Integration/WatcherClientTest.php
+++ b/tests/Integration/WatcherClientTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient\Tests\Integration;
+
+use CrowdSec\LapiClient\Constants;
+use CrowdSec\LapiClient\Tests\Constants as TestConstants;
+use CrowdSec\LapiClient\WatcherClient;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \CrowdSec\LapiClient\WatcherClient
+ */
+final class WatcherClientTest extends TestCase
+{
+    public function testLoginTls(): void
+    {
+        $agentTlsPath = getenv('AGENT_TLS_PATH');
+
+        $bouncerConfigs = [
+            'api_url' => getenv('LAPI_URL'),
+            'appsec_url' => getenv('APPSEC_URL'),
+            'user_agent_suffix' => TestConstants::USER_AGENT_SUFFIX,
+            'auth_type' => Constants::AUTH_TLS,
+            'tls_cert_path' => "{$agentTlsPath}/agent.pem",
+            'tls_key_path' => "{$agentTlsPath}/agent-key.pem",
+            'tls_verify_peer' => false,
+        ];
+
+        $watcher = new WatcherClient($bouncerConfigs);
+        self::assertLoginResult($watcher->login());
+    }
+
+    public function testLoginApiKey(): void
+    {
+        $machineId = getenv('MACHINE_ID') ?: 'watcherLogin';
+        $password = getenv('PASSWORD') ?: 'watcherPassword';
+
+        $bouncerConfigs = [
+            'api_url' => getenv('LAPI_URL'),
+            'appsec_url' => getenv('APPSEC_URL'),
+            'user_agent_suffix' => TestConstants::USER_AGENT_SUFFIX,
+            'auth_type' => Constants::AUTH_KEY,
+            'api_key' => getenv('BOUNCER_KEY'),
+            'machine_id' => $machineId,
+            'password' => $password,
+        ];
+
+        $watcher = new WatcherClient($bouncerConfigs);
+        self::assertLoginResult($watcher->login());
+    }
+
+    private static function assertLoginResult(array $data): void
+    {
+        self::assertArrayHasKey('code', $data);
+        self::assertArrayHasKey('expire', $data);
+        self::assertArrayHasKey('token', $data);
+
+        self::assertSame(200, $data['code']);
+        self::assertMatchesRegularExpression('/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/', $data['expire']);
+        // JWT
+        $parts = explode('.', $data['token']);
+        self::assertCount(3, $parts);
+        $payloadStr = \base64_decode($parts[1]);
+        self::assertNotSame(false, $payloadStr);
+        $payload = \json_decode($payloadStr, true);
+        self::assertNotEmpty($payload);
+        self::assertArrayHasKey('exp', $payload);
+        self::assertTrue(\is_int($payload['exp']));
+        self::assertArrayHasKey('id', $payload);
+        self::assertTrue(\is_string($payload['id']));
+        self::assertArrayHasKey('orig_iat', $payload);
+        self::assertTrue(\is_int($payload['orig_iat']));
+    }
+}

--- a/tests/Unit/FileGetContentsTest.php
+++ b/tests/Unit/FileGetContentsTest.php
@@ -17,7 +17,6 @@ namespace CrowdSec\LapiClient\Tests\Unit;
  * @license   MIT License
  */
 
-use CrowdSec\Common\Client\HttpMessage\Request;
 use CrowdSec\LapiClient\Bouncer;
 use CrowdSec\LapiClient\Tests\MockedData;
 use CrowdSec\LapiClient\TimeoutException;

--- a/tests/Unit/Payload/AlertTest.php
+++ b/tests/Unit/Payload/AlertTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace CrowdSec\LapiClient\Tests\Unit\Payload;
+
+use CrowdSec\LapiClient\Payload\Alert;
+use PHPUnit\Framework\TestCase;
+
+class AlertTest extends TestCase
+{
+    /**
+     * @dataProvider dpConstruct
+     */
+    public function testConstruct(array $in, array $expected): void
+    {
+        $alert = new Alert(
+            $in ?? [],
+            $in['source'] ?? null,
+            $in['decisions'] ?? [],
+            $in['events'] ?? [],
+            $in['meta'] ?? [],
+            $in['labels'] ?? []
+        );
+        self::assertEquals($expected, $alert->toArray());
+    }
+
+    public function dpConstruct(): iterable
+    {
+        $base = [
+            'scenario' => 'crowdsecurity/http-probing',
+            'scenario_hash' => 'abc123',
+            'scenario_version' => '1.0',
+            'message' => 'Probing detected',
+            'events_count' => 3,
+            'start_at' => '2025-01-01T00:00:00Z',
+            'stop_at' => '2025-01-01T00:10:00Z',
+            'capacity' => 10,
+            'leakspeed' => '10/1s',
+            'simulated' => false,
+            'remediation' => true,
+            'source' => [
+                'scope' => 'ip',
+                'value' => '1.2.3.4',
+                'ip' => '1.2.3.4',
+                'range' => '1.2.3.4/32',
+                'as_number' => 'AS12345',
+                'as_name' => 'EXAMPLE-AS',
+                'cn' => 'US',
+                'latitude' => 40.7128,
+                'longitude' => -74.0060,
+            ],
+            'decisions' => [
+                [
+                    'origin' => 'lapi',
+                    'type' => 'ban',
+                    'scope' => 'ip',
+                    'value' => '1.2.3.4',
+                    'duration' => '4h',
+                    'until' => '2025-01-01T04:00:00Z',
+                    'scenario' => 'crowdsecurity/http-probing',
+                ],
+            ],
+            'events' => [
+                [
+                    'meta' => [
+                        ['key' => 'path', 'value' => '/admin'],
+                    ],
+                    'timestamp' => '2025-01-01T00:00:01Z',
+                ],
+            ],
+            'meta' => [
+                ['key' => 'service', 'value' => 'nginx'],
+            ],
+            'labels' => ['http', 'probing'],
+        ];
+        yield 'full example' => [
+            $base,
+            $base,
+        ];
+
+        $minimal = $base;
+        unset(
+            $minimal['event'],
+            $minimal['decisions'],
+            $minimal['source'],
+            $minimal['meta'],
+            $minimal['labels'],
+        );
+        yield 'minimal example' => [
+            $minimal,
+            $minimal,
+        ];
+    }
+}

--- a/tests/Unit/Storage/TokenStorageTest.php
+++ b/tests/Unit/Storage/TokenStorageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CrowdSec\LapiClient\Tests\Unit\Storage;
+
+use CrowdSec\LapiClient\Storage\TokenStorage;
+use CrowdSec\LapiClient\WatcherClient;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * @coversDefaultClass \CrowdSec\LapiClient\Storage\TokenStorage
+ */
+final class TokenStorageTest extends TestCase
+{
+    public function testLoginSuccess(): void
+    {
+        $watcher = $this->createMock(WatcherClient::class);
+        $expire = time() + 3600;
+        $watcher
+            ->expects(self::once())
+            ->method('login')
+            ->willReturn([
+                'code' => 200,
+                'expire' => $expire,
+                'token' => 'j.w.t',
+            ]);
+        $cache = new ArrayAdapter();
+        $storage = new TokenStorage($watcher, $cache);
+        self::assertSame('j.w.t', $storage->retrieveToken());
+        self::assertTrue($cache->hasItem('crowdsec_token'));
+        $ci = $cache->getItem('crowdsec_token');
+        self::assertSame('j.w.t', $ci->get());
+    }
+}

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -27,7 +27,10 @@
         </UndefinedMethod>
         <PropertyTypeCoercion>
             <errorLevel type="suppress">
-                <file name="src/Payload/Alert.php"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$source"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$decisions"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$events"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$meta"/>
             </errorLevel>
         </PropertyTypeCoercion>
     </issueHandlers>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -62,7 +62,7 @@
         </InvalidReturnStatement>
         <RiskyTruthyFalsyComparison>
             <errorLevel type="suppress">
-                <file name="../../../src/Douncer.php"/>
+                <file name="../../../src/Bouncer.php"/>
             </errorLevel>
         </RiskyTruthyFalsyComparison>
         <InvalidArgument>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -27,6 +27,7 @@
         </UndefinedMethod>
         <PropertyTypeCoercion>
             <errorLevel type="suppress">
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$properties"/>
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$source"/>
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$decisions"/>
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$events"/>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -18,6 +18,7 @@
             <errorLevel type="suppress">
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeParentInterface::integerNode"/>
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeParentInterface::scalarNode"/>
+                <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeParentInterface::stringNode"/>
             </errorLevel>
         </UndefinedInterfaceMethod>
         <UndefinedMethod>
@@ -31,7 +32,7 @@
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$source"/>
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$decisions"/>
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$events"/>
-                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$meta"/>
+                <referencedProperty name="CrowdSec\LapiClient\Metrics::$items"/>
             </errorLevel>
         </PropertyTypeCoercion>
         <MissingClassConstType>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -27,11 +27,7 @@
         </UndefinedMethod>
         <PropertyTypeCoercion>
             <errorLevel type="suppress">
-                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$properties"/>
-                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$source"/>
-                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$decisions"/>
-                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$events"/>
-                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$meta"/>
+                <file name="src/Payload/Alert.php"/>
             </errorLevel>
         </PropertyTypeCoercion>
     </issueHandlers>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -32,6 +32,7 @@
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$source"/>
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$decisions"/>
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$events"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$meta"/>
                 <referencedProperty name="CrowdSec\LapiClient\Metrics::$items"/>
             </errorLevel>
         </PropertyTypeCoercion>
@@ -63,6 +64,7 @@
         <InvalidReturnStatement>
             <errorLevel type="suppress">
                 <file name="../../../src/AlertsClient.php"/>
+                <file name="../../../src/Payload/Alert.php"/>
             </errorLevel>
         </InvalidReturnStatement>
         <RiskyTruthyFalsyComparison>
@@ -75,6 +77,11 @@
                 <file name="../../../src/Payload/Alert.php"/>
             </errorLevel>
         </InvalidArgument>
+        <InvalidReturnType>
+            <errorLevel type="suppress">
+                <file name="../../../src/Payload/Alert.php"/>
+            </errorLevel>
+        </InvalidReturnType>
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
                 <file name="../../../src/Payload/Alert.php"/>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -45,5 +45,15 @@
                 <file name="../../../src/AbstractLapiClient.php"/>
             </errorLevel>
         </NonInvariantDocblockPropertyType>
+        <MoreSpecificReturnType>
+            <errorLevel type="info">
+                <file name="../../../src/AlertsClient.php"/>
+            </errorLevel>
+        </MoreSpecificReturnType>
+        <LessSpecificReturnStatement>
+            <errorLevel type="info">
+                <file name="../../../src/AlertsClient.php"/>
+            </errorLevel>
+        </LessSpecificReturnStatement>
     </issueHandlers>
 </psalm>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -25,6 +25,7 @@
             <errorLevel type="suppress">
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeDefinition::children"/>
                 <file name="../../../src/Configuration.php"/>
+                <file name="../../../src/Configuration/Alert.php"/>
                 <file name="../../../src/Payload/Alert.php"/>
             </errorLevel>
         </UndefinedMethod>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -55,6 +55,11 @@
                 <file name="../../../src/AlertsClient.php"/>
             </errorLevel>
         </LessSpecificReturnStatement>
+        <UndefinedDocblockClass>
+            <errorLevel type="suppress">
+                <file name="../../../src/AlertsClient.php"/>
+            </errorLevel>
+        </UndefinedDocblockClass>
         <InvalidReturnStatement>
             <errorLevel type="suppress">
                 <file name="../../../src/AlertsClient.php"/>
@@ -70,5 +75,10 @@
                 <file name="../../../src/Payload/Alert.php"/>
             </errorLevel>
         </InvalidArgument>
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <file name="../../../src/Payload/Alert.php"/>
+            </errorLevel>
+        </PropertyNotSetInConstructor>
     </issueHandlers>
 </psalm>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -55,5 +55,20 @@
                 <file name="../../../src/AlertsClient.php"/>
             </errorLevel>
         </LessSpecificReturnStatement>
+        <InvalidReturnStatement>
+            <errorLevel type="suppress">
+                <file name="../../../src/AlertsClient.php"/>
+            </errorLevel>
+        </InvalidReturnStatement>
+        <RiskyTruthyFalsyComparison>
+            <errorLevel type="suppress">
+                <file name="../../../src/Douncer.php"/>
+            </errorLevel>
+        </RiskyTruthyFalsyComparison>
+        <InvalidArgument>
+            <errorLevel type="suppress">
+                <file name="../../../src/Payload/Alert.php"/>
+            </errorLevel>
+        </InvalidArgument>
     </issueHandlers>
 </psalm>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -40,5 +40,10 @@
                 <directory name="../../../src"/>
             </errorLevel>
         </MissingClassConstType>
+        <NonInvariantDocblockPropertyType>
+            <errorLevel type="suppress">
+                <file name="../../../src/AbstractLapiClient.php"/>
+            </errorLevel>
+        </NonInvariantDocblockPropertyType>
     </issueHandlers>
 </psalm>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -24,6 +24,8 @@
         <UndefinedMethod>
             <errorLevel type="suppress">
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeDefinition::children"/>
+                <file name="../../../src/Configuration.php"/>
+                <file name="../../../src/Payload/Alert.php"/>
             </errorLevel>
         </UndefinedMethod>
         <PropertyTypeCoercion>
@@ -87,5 +89,13 @@
                 <file name="../../../src/Payload/Alert.php"/>
             </errorLevel>
         </PropertyNotSetInConstructor>
+        <PossiblyNullReference>
+            <errorLevel type="suppress">
+                <file name="../../../src/Configuration.php"/>
+                <file name="../../../src/Configuration/Metrics.php"/>
+                <file name="../../../src/Configuration/Metrics/Items.php"/>
+                <file name="../../../src/Configuration/Metrics/Meta.php"/>
+            </errorLevel>
+        </PossiblyNullReference>
     </issueHandlers>
 </psalm>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -46,12 +46,12 @@
             </errorLevel>
         </NonInvariantDocblockPropertyType>
         <MoreSpecificReturnType>
-            <errorLevel type="info">
+            <errorLevel type="suppress">
                 <file name="../../../src/AlertsClient.php"/>
             </errorLevel>
         </MoreSpecificReturnType>
         <LessSpecificReturnStatement>
-            <errorLevel type="info">
+            <errorLevel type="suppress">
                 <file name="../../../src/AlertsClient.php"/>
             </errorLevel>
         </LessSpecificReturnStatement>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -27,11 +27,11 @@
         </UndefinedMethod>
         <PropertyTypeCoercion>
             <errorLevel type="suppress">
-                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureProperties"/>
-                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureSource"/>
-                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureDecisions"/>
-                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureEvents"/>
-                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureMetaList"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$properties"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$source"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$decisions"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$events"/>
+                <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$meta"/>
             </errorLevel>
         </PropertyTypeCoercion>
     </issueHandlers>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -25,5 +25,14 @@
                 <referencedMethod name="Symfony\Component\Config\Definition\Builder\NodeDefinition::children"/>
             </errorLevel>
         </UndefinedMethod>
+        <PropertyTypeCoercion>
+            <errorLevel type="suppress">
+                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureProperties"/>
+                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureSource"/>
+                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureDecisions"/>
+                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureEvents"/>
+                <referencedMethod name="CrowdSec\LapiClient\Payload\Alert::configureMetaList"/>
+            </errorLevel>
+        </PropertyTypeCoercion>
     </issueHandlers>
 </psalm>

--- a/tools/coding-standards/psalm/psalm.xml
+++ b/tools/coding-standards/psalm/psalm.xml
@@ -34,5 +34,10 @@
                 <referencedProperty name="CrowdSec\LapiClient\Payload\Alert::$meta"/>
             </errorLevel>
         </PropertyTypeCoercion>
+        <MissingClassConstType>
+            <errorLevel type="suppress">
+                <directory name="../../../src"/>
+            </errorLevel>
+        </MissingClassConstType>
     </issueHandlers>
 </psalm>


### PR DESCRIPTION
### ✨ Key Changes

1. **Added `AbstractLapiClient`**

   * Extracted common logic for interacting with the LAPI (initialization, HTTP requests, response/error handling).
   * Reduced code duplication across clients.

2. **Added `AlertsClient`**

   * New client for managing LAPI `alerts` endpoints.
   * Implemented methods:

     * `listAlerts()` — retrieve a list of alerts;
     * `getAlertById(int $id)` — fetch a specific alert by ID;
     * `createAlert(array $data)` — create a new alert;
     * `deleteAlert(int $id)` — delete an alert;
     * *(add any other methods if applicable, e.g., update, filter, search, etc.)*

3. **Added integration tests for `AlertsClient`**

   * Covers real (or mocked) interactions with the LAPI;
   * Tests alert creation, retrieval, and deletion flows.

4. **Added `WatcherClient`**

   * Provides authentication for “watcher” clients;
   * Handles token retrieval and renewal.

5. **Added `BouncerClient`**

   * Introduced for consistency across all LAPI clients;
   * The old `Bouncer` class is now marked as **deprecated** and will be removed in a future release.
