### PR TITLE
feat(alert): add optional "kind" property

### DIFF
--- a/src/AlertPusherInterface.php
+++ b/src/AlertPusherInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrowdSec\LapiClient;
+
+/**
+ * @psalm-import-type TAlertFull from \CrowdSec\LapiClient\Payload\Alert
+ */
+interface AlertPusherInterface
+{
+    /**
+     * Push alerts to LAPI.
+     *
+     * @param list<TAlertFull> $alerts
+     *
+     * @return list<string>
+     *
+     * @throws ClientException
+     */
+    public function pushAlerts(array $alerts): array;
+}

--- a/src/Configuration/Alert.php
+++ b/src/Configuration/Alert.php
@@ -23,6 +23,7 @@ class Alert extends AbstractConfiguration
         'leakspeed',
         'simulated',
         'remediation',
+        'kind',
     ];
 
     #[\Override]
@@ -45,6 +46,7 @@ class Alert extends AbstractConfiguration
                 ->scalarNode('leakspeed')->isRequired()->cannotBeEmpty()->end()
                 ->booleanNode('simulated')->isRequired()->end()
                 ->booleanNode('remediation')->isRequired()->end()
+                ->scalarNode('kind')->cannotBeEmpty()->end()
             ->end()
         ;
         // @formatter:on

--- a/src/Payload/Alert.php
+++ b/src/Payload/Alert.php
@@ -26,7 +26,8 @@ use Symfony\Component\Config\Definition\Processor;
  *     capacity: int,
  *     leakspeed: string,
  *     simulated: bool,
- *     remediation: bool
+ *     remediation: bool,
+ *     kind?: string
  * }
  * @psalm-type TSource = array{
  *     scope: string,
@@ -68,6 +69,7 @@ use Symfony\Component\Config\Definition\Processor;
  *     leakspeed: string,
  *     simulated: bool,
  *     remediation: bool,
+ *     kind?: string,
  *     source?: TSource,
  *     events: list<TEvent>,
  *     decisions?: list<TDecision>,
@@ -138,20 +140,25 @@ class Alert implements \JsonSerializable
      */
     public static function fromArray(array $data): self
     {
+        $properties = [
+            'scenario' => $data['scenario'],
+            'scenario_hash' => $data['scenario_hash'],
+            'scenario_version' => $data['scenario_version'],
+            'message' => $data['message'],
+            'events_count' => $data['events_count'],
+            'start_at' => $data['start_at'],
+            'stop_at' => $data['stop_at'],
+            'capacity' => $data['capacity'],
+            'leakspeed' => $data['leakspeed'],
+            'simulated' => $data['simulated'],
+            'remediation' => $data['remediation'],
+        ];
+        if (isset($data['kind'])) {
+            $properties['kind'] = $data['kind'];
+        }
+
         return new self(
-            [
-                'scenario' => $data['scenario'],
-                'scenario_hash' => $data['scenario_hash'],
-                'scenario_version' => $data['scenario_version'],
-                'message' => $data['message'],
-                'events_count' => $data['events_count'],
-                'start_at' => $data['start_at'],
-                'stop_at' => $data['stop_at'],
-                'capacity' => $data['capacity'],
-                'leakspeed' => $data['leakspeed'],
-                'simulated' => $data['simulated'],
-                'remediation' => $data['remediation'],
-            ],
+            $properties,
             $data['source'] ?? null,
             $data['events'] ?? [],
             $data['decisions'] ?? [],

--- a/src/Watcher.php
+++ b/src/Watcher.php
@@ -79,7 +79,7 @@ use Psr\Log\LoggerInterface;
  *     uuid: string
  * }
  */
-class Watcher extends AbstractLapiClient
+class Watcher extends AbstractLapiClient implements AlertPusherInterface
 {
     private const CACHE_KEY = 'crowdsec_watcher_token';
 

--- a/tests/Unit/Payload/AlertTest.php
+++ b/tests/Unit/Payload/AlertTest.php
@@ -54,6 +54,7 @@ class AlertTest extends TestCase
             'leakspeed' => '10/1s',
             'simulated' => false,
             'remediation' => true,
+            'kind' => 'my-app-name',
             'source' => [
                 'scope' => 'ip',
                 'value' => '1.2.3.4',
@@ -122,6 +123,7 @@ class AlertTest extends TestCase
             'leakspeed' => '10/1s',
             'simulated' => false,
             'remediation' => true,
+            'kind' => 'my-app-name',
             'source' => [
                 'scope' => 'ip',
                 'value' => '1.2.3.4',


### PR DESCRIPTION
# feat(alert): add optional "kind" property

## Description

Adds support for the optional `kind` property on alerts. In recent CrowdSec
versions `kind` is a top-level field of the Alert model ("origin of the alert",
e.g. `crowdsec`, `waf`, `bot-detection`, …) and is rendered as a dedicated column
by `cscli alerts list` (also filterable via `--kind`). This lets an application
tag its pushed alerts (e.g. `kind = <app-name>`) so they are easy to spot.

## Changes

- `Configuration\Alert`: register `kind` as an optional (non-required) scalar node,
  mirroring the existing optional `Source` fields.
- `Payload\Alert`: add `kind` to the `TProps` / `TAlertFull` psalm types; it is
  emitted in `toArray()` / `jsonSerialize()` only when provided, and
  `fromArray()` passes it through only when present (no `kind` key when unset).
- Introduce `AlertPusherInterface` (declares `pushAlerts()`); `Watcher` now
  implements it, so the client can be type-hinted / mocked against an abstraction.
- Tests updated to cover the `kind` round-trip.

## Usage

```php
$alert = \CrowdSec\LapiClient\Payload\Alert::fromArray([
    // ... required alert fields ...
    'kind'   => 'my-app-name',
    'source' => ['scope' => 'Ip', 'value' => '1.2.3.4'],
]);

$watcher->pushAlerts([$alert->toArray()]);
```

## Backward compatibility

`kind` is optional — existing payloads that don't set it are unaffected and no
`kind` key is added to their output.

## Tests

`php vendor/bin/phpunit tests/Unit` → 31 passed, 88 assertions.
